### PR TITLE
Load seq.el for using seqp

### DIFF
--- a/helm-icons.el
+++ b/helm-icons.el
@@ -31,6 +31,7 @@
 (require 'treemacs-themes)
 (require 'treemacs-icons)
 (require 'dash)
+(require 'seq)
 
 (defgroup helm-icons nil
   "Helm treemacs icons."


### PR DESCRIPTION
There is a following byte-compile warning in original code.

```
helm-icons.el:126:1:Warning: the function ‘seqp’ is not known to be defined.
```