### PR TITLE
Get buffer icon from mode before falling to other options

### DIFF
--- a/helm-icons.el
+++ b/helm-icons.el
@@ -66,7 +66,7 @@
   (cond ((eq helm-icons-provider 'all-the-icons)
          (require 'all-the-icons)
          (concat
-          (or (cond ((not file) (all-the-icons-octicon "gear"))
+          (or (cond ((not (stringp file)) (all-the-icons-octicon "gear"))
                     ((or
                       (member (f-base file) '("." ".."))
                       (f-dir? file))
@@ -78,15 +78,25 @@
          (require 'treemacs-themes)
          (helm-icons--treemacs-icon file))))
 
+(defun helm-icons--get-icon-for-mode (mode)
+  "Get icon for mode. First it will use the customized
+helm-icons-mode->icon to resolve the icon, otherwise it tries to
+use the provider."
+  (or (-some->> (assoc major-mode helm-icons-mode->icon)
+           (cl-rest)
+           helm-icons--get-icon)
+      (cond ((eq helm-icons-provider 'all-the-icons)
+             (-let ((icon (all-the-icons-icon-for-mode mode)))
+               (when (stringp icon) (concat icon " "))))
+            (t nil))))
+
 (defun helm-icons-buffers-add-icon (candidates _source)
   "Add icon to buffers source.
 CANDIDATES is the list of candidates."
   (-map (-lambda ((display . buffer))
           (cons (concat
                  (with-current-buffer buffer
-                   (or (->> (assoc major-mode helm-icons-mode->icon)
-                            (cl-rest)
-                            helm-icons--get-icon)
+                   (or (helm-icons--get-icon-for-mode major-mode)
                        (-some->> (buffer-file-name)
                          helm-icons--get-icon)
                        (helm-icons--get-icon 'fallback)))


### PR DESCRIPTION
Get buffer icon from mode before falling to other options
+ fix error while resolving (helm-icons--get-icon 'fallback) with 'all-the-icons provider (#16)