### PR TITLE
Added support for helm-ls-git and helm-browse-project.

### DIFF
--- a/helm-icons.el
+++ b/helm-icons.el
@@ -126,7 +126,7 @@ ORIG is the original function.
 NAME, CLASS and ARGS are the original params."
   (let ((result (apply orig name class args)))
     (cl-case class
-      ((helm-recentf-source helm-source-ffiles helm-locate-source helm-fasd-source)
+      ((helm-recentf-source helm-source-ffiles helm-locate-source helm-fasd-source helm-ls-git-source)
        (helm-icons-add-transformer
         #'helm-icons-files-add-icons
         result))


### PR DESCRIPTION
Hi, can we consider add support for `helm-ls-git` and `helm-browse-project`? latter use former, and former is officially support by helm too.